### PR TITLE
Add support for extra small icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,8 @@ The widget provides three types of buttons
 ```php 
     echo Share::widget([
         'type' => Share::TYPE_EXTRA_SMALL
-       
+```
+
 ```php 
     echo Share::widget([
         'type' => Share::TYPE_SMALL

--- a/README.md
+++ b/README.md
@@ -103,10 +103,15 @@ By default the main container has an id attribute similar to #w0, you can change
 ```
 
 #### Widget button types 
-The widget provides to types of buttons
+The widget provides three types of buttons
+    extra-small (small icons only)
     small (icon only)
     large (icon + text)
-    
+ 
+```php 
+    echo Share::widget([
+        'type' => Share::TYPE_EXTRA_SMALL
+       
 ```php 
     echo Share::widget([
         'type' => Share::TYPE_SMALL

--- a/src/Widget.php
+++ b/src/Widget.php
@@ -11,6 +11,11 @@ use bigpaulie\social\share\ShareAsset;
  * @package bigpaulie\social\share
  */
 class Widget extends \yii\base\Widget {
+    /**
+     * Widget type with extra small buttons
+     * @var string
+     */
+    const TYPE_EXTRA_SMALL = 'extra-small';
 
     /**
      * Widget type with small buttons
@@ -180,6 +185,14 @@ class Widget extends \yii\base\Widget {
             $url = $this->networks[$network];
 
             switch ($this->type) {
+                case self::TYPE_EXTRA_SMALL:
+                    $button = str_replace(
+                        '{button}',
+                        '<a href="#" class="btn btn-sm btn-social-icon btn-{network}" onClick="sharePopup(\'' . $url . '\');">'
+                        . '<i class="fa fa-{network}"></i></a>',
+                        $this->template
+                    );
+                    break;
                 case self::TYPE_SMALL:
                     $button = str_replace(
                         '{button}',


### PR DESCRIPTION
btn-sm bootstrap class is added when the 'type' parameter is equal to 'extra-small' or Share::TYPE_EXTRA_SMALL 